### PR TITLE
Add scraper, LLM API integration, unit tests, and refactor main

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,16 @@ backend/tmp/
 
 # backend/.env
 backend/.env
+
+# Go build cache
+backend/.gocache/
+.gocache/
+
+# Go test binary / built binary
+backend/api
+
+# Backup files
+*.bak
+
+# macOS junk
+.DS_Store

--- a/backend/cmd/api/ai.go
+++ b/backend/cmd/api/ai.go
@@ -1,0 +1,195 @@
+// package main
+
+// import (
+// 	"bytes"
+// 	"encoding/json"
+// 	"fmt"
+// 	"io"
+// 	"net/http"
+// 	"os"
+// 	"strings"
+// 	"time"
+// )
+
+// func summarizeWithGroq(content string) (string, error) {
+// 	apiKey := os.Getenv("GROQ_API_KEY")
+// 	if apiKey == "" {
+// 		return "", fmt.Errorf("missing GROQ_API_KEY environment variable")
+// 	}
+
+// 	prompt := `You are a news summarization assistant.
+
+// Summarize the following news articles in no more than 50 words.
+// Focus only on the key developments.
+// Be factual, concise, and clear.
+// Do not add extra information or opinions.
+
+// Articles:
+// ` + content
+
+// 	payload := map[string]any{
+// 		"model": "llama-3.3-70b-versatile",
+// 		"messages": []map[string]string{
+// 			{
+// 				"role":    "system",
+// 				"content": "You summarize news clearly and accurately.",
+// 			},
+// 			{
+// 				"role":    "user",
+// 				"content": prompt,
+// 			},
+// 		},
+// 		"temperature": 0.2,
+// 	}
+
+// 	bodyBytes, err := json.Marshal(payload)
+// 	if err != nil {
+// 		return "", fmt.Errorf("failed to marshal Groq request")
+// 	}
+
+// 	req, err := http.NewRequest(
+// 		http.MethodPost,
+// 		"https://api.groq.com/openai/v1/chat/completions",
+// 		bytes.NewBuffer(bodyBytes),
+// 	)
+// 	if err != nil {
+// 		return "", fmt.Errorf("failed to create Groq request")
+// 	}
+
+// 	req.Header.Set("Content-Type", "application/json")
+// 	req.Header.Set("Authorization", "Bearer "+apiKey)
+
+// 	client := &http.Client{Timeout: 20 * time.Second}
+// 	res, err := client.Do(req)
+// 	if err != nil {
+// 		return "", fmt.Errorf("failed to call Groq API")
+// 	}
+// 	defer res.Body.Close()
+
+// 	respBody, err := io.ReadAll(res.Body)
+// 	if err != nil {
+// 		return "", fmt.Errorf("failed to read Groq response")
+// 	}
+
+// 	if res.StatusCode != http.StatusOK {
+// 		return "", fmt.Errorf("Groq returned status %d: %s", res.StatusCode, string(respBody))
+// 	}
+
+// 	var parsed struct {
+// 		Choices []struct {
+// 			Message struct {
+// 				Content string `json:"content"`
+// 			} `json:"message"`
+// 		} `json:"choices"`
+// 	}
+
+// 	if err := json.Unmarshal(respBody, &parsed); err != nil {
+// 		return "", fmt.Errorf("failed to parse Groq response: %s", string(respBody))
+// 	}
+
+// 	if len(parsed.Choices) == 0 {
+// 		return "", fmt.Errorf("Groq response contained no choices")
+// 	}
+
+//		return strings.TrimSpace(parsed.Choices[0].Message.Content), nil
+//	}
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"strings"
+	"time"
+)
+
+func summarizeWithGroq(content string) (string, error) {
+	apiKey := os.Getenv("GROQ_API_KEY")
+	if apiKey == "" {
+		return "", fmt.Errorf("missing GROQ_API_KEY environment variable")
+	}
+
+	prompt := `Summarize the following news article in one clear paragraph.
+
+Rules:
+- Write between 60 and 70 words
+- No bullet points
+- No numbering
+- No intro text
+- Be factual and clear
+- Cover the main development and key context
+- Only use information from the article
+
+Article:
+` + content
+
+	payload := map[string]any{
+		"model": "llama-3.3-70b-versatile",
+		"messages": []map[string]string{
+			{
+				"role":    "system",
+				"content": "You summarize one news article into one plain-text paragraph between 60 and 70 words.",
+			},
+			{
+				"role":    "user",
+				"content": prompt,
+			},
+		},
+		"temperature": 0.2,
+		"max_tokens":  150,
+	}
+
+	bodyBytes, err := json.Marshal(payload)
+	if err != nil {
+		return "", fmt.Errorf("failed to marshal Groq request")
+	}
+
+	req, err := http.NewRequest(
+		http.MethodPost,
+		"https://api.groq.com/openai/v1/chat/completions",
+		bytes.NewBuffer(bodyBytes),
+	)
+	if err != nil {
+		return "", fmt.Errorf("failed to create Groq request")
+	}
+
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer "+apiKey)
+
+	client := &http.Client{Timeout: 20 * time.Second}
+	res, err := client.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("failed to call Groq API")
+	}
+	defer res.Body.Close()
+
+	respBody, err := io.ReadAll(res.Body)
+	if err != nil {
+		return "", fmt.Errorf("failed to read Groq response")
+	}
+
+	if res.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("Groq returned status %d: %s", res.StatusCode, string(respBody))
+	}
+
+	var parsed struct {
+		Choices []struct {
+			Message struct {
+				Content string `json:"content"`
+			} `json:"message"`
+		} `json:"choices"`
+	}
+
+	if err := json.Unmarshal(respBody, &parsed); err != nil {
+		return "", fmt.Errorf("failed to parse Groq response: %s", string(respBody))
+	}
+
+	if len(parsed.Choices) == 0 {
+		return "", fmt.Errorf("Groq response contained no choices")
+	}
+
+	return strings.TrimSpace(parsed.Choices[0].Message.Content), nil
+}

--- a/backend/cmd/api/backend_test.go
+++ b/backend/cmd/api/backend_test.go
@@ -1,0 +1,288 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripFunc) RoundTrip(r *http.Request) (*http.Response, error) {
+	return f(r)
+}
+
+func withMockTransport(t *testing.T, fn roundTripFunc) {
+	t.Helper()
+
+	original := http.DefaultTransport
+	http.DefaultTransport = fn
+
+	t.Cleanup(func() {
+		http.DefaultTransport = original
+	})
+}
+
+func jsonResponse(status int, body string) *http.Response {
+	return &http.Response{
+		StatusCode: status,
+		Header:     http.Header{"Content-Type": []string{"application/json"}},
+		Body:       io.NopCloser(bytes.NewBufferString(body)),
+	}
+}
+
+func htmlResponse(status int, body string) *http.Response {
+	return &http.Response{
+		StatusCode: status,
+		Header:     http.Header{"Content-Type": []string{"text/html"}},
+		Body:       io.NopCloser(bytes.NewBufferString(body)),
+	}
+}
+
+// 1) writeJSONError
+func TestWriteJSONError(t *testing.T) {
+	rr := httptest.NewRecorder()
+
+	writeJSONError(rr, http.StatusBadRequest, "bad request")
+
+	if rr.Code != http.StatusBadRequest {
+		t.Fatalf("expected status %d, got %d", http.StatusBadRequest, rr.Code)
+	}
+
+	if ct := rr.Header().Get("Content-Type"); ct != "application/json" {
+		t.Fatalf("expected content-type application/json, got %s", ct)
+	}
+
+	var got map[string]any
+	if err := json.Unmarshal(rr.Body.Bytes(), &got); err != nil {
+		t.Fatalf("failed to decode response JSON: %v", err)
+	}
+
+	if got["success"] != false {
+		t.Fatalf("expected success=false, got %v", got["success"])
+	}
+
+	if got["error"] != "bad request" {
+		t.Fatalf("expected error 'bad request', got %v", got["error"])
+	}
+}
+
+// 2) parseDotEnv
+func TestParseDotEnv(t *testing.T) {
+	dir := t.TempDir()
+	envPath := filepath.Join(dir, ".env")
+
+	content := `
+# comment
+NEWSAPI_KEY=test-news-key
+GROQ_API_KEY="test-groq-key"
+EMPTY_VALUE=
+`
+	if err := os.WriteFile(envPath, []byte(content), 0o600); err != nil {
+		t.Fatalf("failed to write temp env file: %v", err)
+	}
+
+	_ = os.Unsetenv("NEWSAPI_KEY")
+	_ = os.Unsetenv("GROQ_API_KEY")
+	_ = os.Unsetenv("EMPTY_VALUE")
+
+	if err := parseDotEnv(envPath); err != nil {
+		t.Fatalf("parseDotEnv returned error: %v", err)
+	}
+
+	if got := os.Getenv("NEWSAPI_KEY"); got != "test-news-key" {
+		t.Fatalf("expected NEWSAPI_KEY=test-news-key, got %q", got)
+	}
+
+	if got := os.Getenv("GROQ_API_KEY"); got != "test-groq-key" {
+		t.Fatalf("expected GROQ_API_KEY=test-groq-key, got %q", got)
+	}
+
+	if got := os.Getenv("EMPTY_VALUE"); got != "" {
+		t.Fatalf("expected EMPTY_VALUE='', got %q", got)
+	}
+}
+
+// 3) loadDotEnv
+func TestLoadDotEnv(t *testing.T) {
+	dir := t.TempDir()
+
+	originalWD, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("failed to get working directory: %v", err)
+	}
+	defer func() {
+		_ = os.Chdir(originalWD)
+	}()
+
+	if err := os.Chdir(dir); err != nil {
+		t.Fatalf("failed to chdir to temp dir: %v", err)
+	}
+
+	envContent := "NEWSAPI_KEY=loaded-from-loadDotEnv\n"
+	if err := os.WriteFile(".env", []byte(envContent), 0o600); err != nil {
+		t.Fatalf("failed to write .env: %v", err)
+	}
+
+	_ = os.Unsetenv("NEWSAPI_KEY")
+
+	loadDotEnv()
+
+	if got := os.Getenv("NEWSAPI_KEY"); got != "loaded-from-loadDotEnv" {
+		t.Fatalf("expected NEWSAPI_KEY=loaded-from-loadDotEnv, got %q", got)
+	}
+}
+
+// 4) summarizeWithGroq
+func TestSummarizeWithGroq(t *testing.T) {
+	t.Setenv("GROQ_API_KEY", "test-groq-key")
+
+	withMockTransport(t, func(req *http.Request) (*http.Response, error) {
+		if req.URL.String() != "https://api.groq.com/openai/v1/chat/completions" {
+			t.Fatalf("unexpected URL: %s", req.URL.String())
+		}
+
+		if got := req.Header.Get("Authorization"); got != "Bearer test-groq-key" {
+			t.Fatalf("unexpected Authorization header: %s", got)
+		}
+
+		body, err := io.ReadAll(req.Body)
+		if err != nil {
+			t.Fatalf("failed to read request body: %v", err)
+		}
+
+		if !strings.Contains(string(body), "Tesla expands in Canada") {
+			t.Fatalf("expected request body to contain article text, got: %s", string(body))
+		}
+
+		mockGroqJSON := `{
+			"choices": [
+				{
+					"message": {
+						"content": "Tesla expands in Canada amid stronger EV competition."
+					}
+				}
+			]
+		}`
+
+		return jsonResponse(http.StatusOK, mockGroqJSON), nil
+	})
+
+	summary, err := summarizeWithGroq("Tesla expands in Canada")
+	if err != nil {
+		t.Fatalf("summarizeWithGroq returned error: %v", err)
+	}
+
+	expected := "Tesla expands in Canada amid stronger EV competition."
+	if summary != expected {
+		t.Fatalf("expected %q, got %q", expected, summary)
+	}
+}
+
+// 5) extractArticleText
+func TestExtractArticleText(t *testing.T) {
+	withMockTransport(t, func(req *http.Request) (*http.Response, error) {
+		return htmlResponse(http.StatusForbidden, "<html><body>forbidden</body></html>"), nil
+	})
+
+	_, err := extractArticleText("https://example.com/article")
+	if err == nil {
+		t.Fatal("expected extractArticleText to return an error for non-200 response")
+	}
+
+	if !strings.Contains(err.Error(), "article page returned status 403") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+// 6) newsHandler
+func TestNewsHandler(t *testing.T) {
+	t.Setenv("NEWSAPI_KEY", "test-news-key")
+	t.Setenv("GROQ_API_KEY", "test-groq-key")
+
+	withMockTransport(t, func(req *http.Request) (*http.Response, error) {
+		switch {
+		case strings.Contains(req.URL.Host, "newsapi.org"):
+			mockNewsAPIJSON := `{
+				"status": "ok",
+				"totalResults": 1,
+				"articles": [
+					{
+						"source": { "id": null, "name": "Electrek" },
+						"author": "Reporter",
+						"title": "Tesla expands in Canada",
+						"description": "Expansion news",
+						"url": "https://example.com/article",
+						"urlToImage": "https://example.com/image.jpg",
+						"publishedAt": "2026-03-25T10:00:00Z",
+						"content": "Snippet from NewsAPI"
+					}
+				]
+			}`
+			return jsonResponse(http.StatusOK, mockNewsAPIJSON), nil
+
+		case req.URL.String() == "https://example.com/article":
+			html := `
+			<!doctype html>
+			<html>
+			<head><title>Tesla Article</title></head>
+			<body>
+				<article>
+					<p>Tesla is opening new locations in Canada and expanding its EV presence.</p>
+					<p>The move reflects stronger market momentum.</p>
+				</article>
+			</body>
+			</html>`
+			return htmlResponse(http.StatusOK, html), nil
+
+		case strings.Contains(req.URL.Host, "api.groq.com"):
+			mockGroqJSON := `{
+				"choices": [
+					{
+						"message": {
+							"content": "Tesla is expanding its Canadian presence through new locations and broader EV market growth."
+						}
+					}
+				]
+			}`
+			return jsonResponse(http.StatusOK, mockGroqJSON), nil
+
+		default:
+			t.Fatalf("unexpected request URL: %s", req.URL.String())
+			return nil, nil
+		}
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/news?q=tesla", nil)
+	rr := httptest.NewRecorder()
+
+	newsHandler(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected status %d, got %d", http.StatusOK, rr.Code)
+	}
+
+	var got NewsAPIResponse
+	if err := json.Unmarshal(rr.Body.Bytes(), &got); err != nil {
+		t.Fatalf("failed to decode handler response: %v", err)
+	}
+
+	if len(got.Articles) != 1 {
+		t.Fatalf("expected 1 article, got %d", len(got.Articles))
+	}
+
+	if got.Articles[0].Summary == "" {
+		t.Fatal("expected article summary to be populated")
+	}
+
+	expectedSummary := "Tesla is expanding its Canadian presence through new locations and broader EV market growth."
+	if got.Articles[0].Summary != expectedSummary {
+		t.Fatalf("expected summary %q, got %q", expectedSummary, got.Articles[0].Summary)
+	}
+}

--- a/backend/cmd/api/main.go
+++ b/backend/cmd/api/main.go
@@ -1,145 +1,16 @@
 package main
 
 import (
-	"bufio"
-	"encoding/json"
-	"io"
 	"log"
 	"net/http"
-	"os"
-	"path/filepath"
-	"strings"
-	"time"
 )
 
-// main is the entry point of the application.
-// It loads environment variables, registers HTTP routes,
-// and starts the HTTP server.
 func main() {
-	// Load environment variables from .env file (if present)
 	loadDotEnv()
 
-	// Create a new HTTP request multiplexer (router)
 	mux := http.NewServeMux()
-
-	// Register /news endpoint and bind it to newsHandler
 	mux.HandleFunc("/news", newsHandler)
 
 	log.Println("server listening on http://localhost:8080")
-
-	// Start HTTP server on port 8080
-	// If the server fails, log.Fatal will exit the program
 	log.Fatal(http.ListenAndServe(":8080", mux))
-}
-
-// newsHandler handles GET requests to /news.
-// It fetches news articles from NewsAPI and forwards the response.
-func newsHandler(w http.ResponseWriter, _ *http.Request) {
-
-	// Read NewsAPI key from environment variables
-	apiKey := os.Getenv("NEWSAPI_KEY")
-	if apiKey == "" {
-		writeJSONError(w, http.StatusInternalServerError, "missing NEWSAPI_KEY environment variable")
-		return
-	}
-
-	// Create a new HTTP request to NewsAPI
-	req, err := http.NewRequest(http.MethodGet, "https://newsapi.org/v2/everything?q=tesla", nil)
-	if err != nil {
-		writeJSONError(w, http.StatusBadGateway, "failed to create NewsAPI request")
-		return
-	}
-
-	// Set API key in request header
-	req.Header.Set("X-Api-Key", apiKey)
-
-	// Create HTTP client with timeout to avoid hanging requests
-	client := &http.Client{Timeout: 8 * time.Second}
-
-	// Execute request to NewsAPI
-	res, err := client.Do(req)
-	if err != nil {
-		writeJSONError(w, http.StatusBadGateway, "failed to call NewsAPI")
-		return
-	}
-	defer res.Body.Close()
-
-	// Forward response content-type header
-	contentType := res.Header.Get("Content-Type")
-	if contentType == "" {
-		contentType = "application/json"
-	}
-
-	w.Header().Set("Content-Type", contentType)
-	w.WriteHeader(res.StatusCode)
-
-	// Stream NewsAPI response body directly to client
-	if _, err := io.Copy(w, res.Body); err != nil {
-		log.Printf("failed to copy NewsAPI response: %v", err)
-	}
-}
-
-// writeJSONError sends a standardized JSON error response.
-func writeJSONError(w http.ResponseWriter, status int, message string) {
-	w.Header().Set("Content-Type", "application/json")
-	w.WriteHeader(status)
-
-	// Encode error response as JSON
-	_ = json.NewEncoder(w).Encode(map[string]any{
-		"success": false,
-		"error":   message,
-	})
-}
-
-// loadDotEnv attempts to load environment variables
-// from common .env file locations.
-func loadDotEnv() {
-	paths := []string{"backend/.env", ".env"}
-
-	for _, p := range paths {
-		if err := parseDotEnv(p); err == nil {
-			return
-		}
-	}
-}
-
-// parseDotEnv reads a .env file and sets environment variables.
-// It ignores empty lines and comments.
-func parseDotEnv(path string) error {
-	f, err := os.Open(filepath.Clean(path))
-	if err != nil {
-		return err
-	}
-	defer f.Close()
-
-	scanner := bufio.NewScanner(f)
-
-	for scanner.Scan() {
-		line := strings.TrimSpace(scanner.Text())
-
-		// Skip empty lines and comments
-		if line == "" || strings.HasPrefix(line, "#") {
-			continue
-		}
-
-		// Split key=value format
-		parts := strings.SplitN(line, "=", 2)
-		if len(parts) != 2 {
-			continue
-		}
-
-		key := strings.TrimSpace(parts[0])
-		val := strings.Trim(strings.TrimSpace(parts[1]), `"'`)
-
-		if key == "" {
-			continue
-		}
-
-		// Only set variable if not already defined
-		if _, exists := os.LookupEnv(key); !exists {
-			_ = os.Setenv(key, val)
-		}
-	}
-
-	return scanner.Err()
 }

--- a/backend/cmd/api/news.go
+++ b/backend/cmd/api/news.go
@@ -1,0 +1,370 @@
+// package main
+
+// import (
+// 	"io"
+// 	"log"
+// 	"net/http"
+// 	"net/url"
+// 	"os"
+// 	"time"
+// )
+
+// func newsHandler(w http.ResponseWriter, r *http.Request) {
+// 	apiKey := os.Getenv("NEWSAPI_KEY")
+// 	if apiKey == "" {
+// 		writeJSONError(w, http.StatusInternalServerError, "missing NEWSAPI_KEY environment variable")
+// 		return
+// 	}
+
+// 	// Optional query param: /news?q=tesla
+// 	query := r.URL.Query().Get("q")
+// 	if query == "" {
+// 		query = "tesla"
+// 	}
+
+// 	newsURL := "https://newsapi.org/v2/everything?q=" +
+// 		url.QueryEscape(query) +
+// 		"&sortBy=publishedAt&pageSize=2&language=en"
+
+// 	req, err := http.NewRequest(http.MethodGet, newsURL, nil)
+// 	if err != nil {
+// 		writeJSONError(w, http.StatusBadGateway, "failed to create NewsAPI request")
+// 		return
+// 	}
+
+// 	req.Header.Set("X-Api-Key", apiKey)
+
+// 	client := &http.Client{Timeout: 8 * time.Second}
+
+// 	res, err := client.Do(req)
+// 	if err != nil {
+// 		writeJSONError(w, http.StatusBadGateway, "failed to call NewsAPI")
+// 		return
+// 	}
+// 	defer res.Body.Close()
+
+// 	contentType := res.Header.Get("Content-Type")
+// 	if contentType == "" {
+// 		contentType = "application/json"
+// 	}
+
+// 	w.Header().Set("Content-Type", contentType)
+// 	w.WriteHeader(res.StatusCode)
+
+// 	if _, err := io.Copy(w, res.Body); err != nil {
+// 		log.Printf("failed to copy NewsAPI response: %v", err)
+// 	}
+// }
+
+// package main
+
+// import (
+// 	"encoding/json"
+// 	"net/http"
+// 	"net/url"
+// 	"os"
+// 	"strings"
+// 	"time"
+// )
+
+// type NewsAPIResponse struct {
+// 	Status       string    `json:"status"`
+// 	TotalResults int       `json:"totalResults"`
+// 	Articles     []Article `json:"articles"`
+// }
+
+// type Article struct {
+// 	Source      Source `json:"source"`
+// 	Author      string `json:"author"`
+// 	Title       string `json:"title"`
+// 	Description string `json:"description"`
+// 	URL         string `json:"url"`
+// 	URLToImage  string `json:"urlToImage"`
+// 	PublishedAt string `json:"publishedAt"`
+// 	Content     string `json:"content"`
+// 	Summary     string `json:"summary,omitempty"`
+// }
+
+// type Source struct {
+// 	ID   any    `json:"id"`
+// 	Name string `json:"name"`
+// }
+
+// func newsHandler(w http.ResponseWriter, r *http.Request) {
+// 	apiKey := os.Getenv("NEWSAPI_KEY")
+// 	if apiKey == "" {
+// 		writeJSONError(w, http.StatusInternalServerError, "missing NEWSAPI_KEY environment variable")
+// 		return
+// 	}
+
+// 	query := r.URL.Query().Get("q")
+// 	if query == "" {
+// 		query = "tesla"
+// 	}
+
+// 	newsURL := "https://newsapi.org/v2/everything?q=" +
+// 		url.QueryEscape(query) +
+// 		"&sortBy=publishedAt&pageSize=5&language=en"
+
+// 	req, err := http.NewRequest(http.MethodGet, newsURL, nil)
+// 	if err != nil {
+// 		writeJSONError(w, http.StatusBadGateway, "failed to create NewsAPI request")
+// 		return
+// 	}
+
+// 	req.Header.Set("X-Api-Key", apiKey)
+
+// 	client := &http.Client{Timeout: 8 * time.Second}
+// 	res, err := client.Do(req)
+// 	if err != nil {
+// 		writeJSONError(w, http.StatusBadGateway, "failed to call NewsAPI")
+// 		return
+// 	}
+// 	defer res.Body.Close()
+
+// 	if res.StatusCode != http.StatusOK {
+// 		writeJSONError(w, http.StatusBadGateway, "NewsAPI returned non-200 response")
+// 		return
+// 	}
+
+// 	var newsResp NewsAPIResponse
+// 	if err := json.NewDecoder(res.Body).Decode(&newsResp); err != nil {
+// 		writeJSONError(w, http.StatusBadGateway, "failed to decode NewsAPI response")
+// 		return
+// 	}
+
+// 	if len(newsResp.Articles) == 0 {
+// 		_ = json.NewEncoder(w).Encode(map[string]any{
+// 			"success": true,
+// 			"summary": "No articles found.",
+// 		})
+// 		return
+// 	}
+
+// 	var parts []string
+// 	for _, article := range newsResp.Articles {
+// 		part := "Title: " + article.Title + "\n" +
+// 			"Description: " + article.Description + "\n" +
+// 			"Content: " + article.Content
+// 		parts = append(parts, part)
+// 	}
+
+// 	combinedText := strings.Join(parts, "\n\n---\n\n")
+
+// 	summary, err := summarizeWithGroq(combinedText)
+// 	if err != nil {
+// 		writeJSONError(w, http.StatusBadGateway, "failed to summarize news: "+err.Error())
+// 		return
+// 	}
+
+// 	w.Header().Set("Content-Type", "application/json")
+// 	_ = json.NewEncoder(w).Encode(map[string]any{
+// 		"success": true,
+// 		"query":   query,
+// 		"summary": summary,
+// 	})
+// }
+
+// package main
+
+// import (
+// 	"encoding/json"
+// 	"net/http"
+// 	"net/url"
+// 	"os"
+// 	"time"
+// )
+
+// type NewsAPIResponse struct {
+// 	Status       string    `json:"status"`
+// 	TotalResults int       `json:"totalResults"`
+// 	Articles     []Article `json:"articles"`
+// }
+
+// type Article struct {
+// 	Source      Source `json:"source"`
+// 	Author      string `json:"author"`
+// 	Title       string `json:"title"`
+// 	Description string `json:"description"`
+// 	URL         string `json:"url"`
+// 	URLToImage  string `json:"urlToImage"`
+// 	PublishedAt string `json:"publishedAt"`
+// 	Content     string `json:"content"`
+// 	Summary     string `json:"summary,omitempty"`
+// }
+
+// type Source struct {
+// 	ID   any    `json:"id"`
+// 	Name string `json:"name"`
+// }
+
+// func newsHandler(w http.ResponseWriter, r *http.Request) {
+// 	apiKey := os.Getenv("NEWSAPI_KEY")
+// 	if apiKey == "" {
+// 		writeJSONError(w, http.StatusInternalServerError, "missing NEWSAPI_KEY environment variable")
+// 		return
+// 	}
+
+// 	query := r.URL.Query().Get("q")
+// 	if query == "" {
+// 		query = "tesla"
+// 	}
+
+// 	newsURL := "https://newsapi.org/v2/everything?q=" +
+// 		url.QueryEscape(query) +
+// 		"&sortBy=publishedAt&pageSize=2&language=en"
+
+// 	req, err := http.NewRequest(http.MethodGet, newsURL, nil)
+// 	if err != nil {
+// 		writeJSONError(w, http.StatusBadGateway, "failed to create NewsAPI request")
+// 		return
+// 	}
+
+// 	req.Header.Set("X-Api-Key", apiKey)
+
+// 	client := &http.Client{Timeout: 8 * time.Second}
+// 	res, err := client.Do(req)
+// 	if err != nil {
+// 		writeJSONError(w, http.StatusBadGateway, "failed to call NewsAPI")
+// 		return
+// 	}
+// 	defer res.Body.Close()
+
+// 	if res.StatusCode != http.StatusOK {
+// 		writeJSONError(w, http.StatusBadGateway, "NewsAPI returned non-200 response")
+// 		return
+// 	}
+
+// 	var newsResp NewsAPIResponse
+// 	if err := json.NewDecoder(res.Body).Decode(&newsResp); err != nil {
+// 		writeJSONError(w, http.StatusBadGateway, "failed to decode NewsAPI response")
+// 		return
+// 	}
+
+// 	for i := range newsResp.Articles {
+// 		articleText := "Title: " + newsResp.Articles[i].Title + "\n" +
+// 			"Description: " + newsResp.Articles[i].Description + "\n" +
+// 			"Content: " + newsResp.Articles[i].Content
+
+// 		summary, err := summarizeWithGroq(articleText)
+// 		if err != nil {
+// 			newsResp.Articles[i].Summary = "summary unavailable"
+// 			continue
+// 		}
+
+// 		newsResp.Articles[i].Summary = summary
+// 	}
+
+// 	w.Header().Set("Content-Type", "application/json")
+// 	_ = json.NewEncoder(w).Encode(newsResp)
+// }
+
+package main
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/url"
+	"os"
+	"strings"
+	"time"
+)
+
+type NewsAPIResponse struct {
+	Status       string    `json:"status"`
+	TotalResults int       `json:"totalResults"`
+	Articles     []Article `json:"articles"`
+}
+
+type Article struct {
+	Source      Source `json:"source"`
+	Author      string `json:"author"`
+	Title       string `json:"title"`
+	Description string `json:"description"`
+	URL         string `json:"url"`
+	URLToImage  string `json:"urlToImage"`
+	PublishedAt string `json:"publishedAt"`
+	Content     string `json:"content"`
+	Summary     string `json:"summary,omitempty"`
+}
+
+type Source struct {
+	ID   any    `json:"id"`
+	Name string `json:"name"`
+}
+
+// Handles /news endpoint
+func newsHandler(w http.ResponseWriter, r *http.Request) {
+	// Get API key from environment
+	apiKey := os.Getenv("NEWSAPI_KEY")
+	if apiKey == "" {
+		writeJSONError(w, http.StatusInternalServerError, "missing NEWSAPI_KEY environment variable")
+		return
+	}
+
+	// Read query param (?q=...)
+	query := r.URL.Query().Get("q")
+	if query == "" {
+		query = "tesla"
+	}
+
+	// Build NewsAPI request URL
+	newsURL := "https://newsapi.org/v2/everything?q=" +
+		url.QueryEscape(query) +
+		"&sortBy=publishedAt&pageSize=2&language=en"
+
+	req, err := http.NewRequest(http.MethodGet, newsURL, nil)
+	if err != nil {
+		writeJSONError(w, http.StatusBadGateway, "failed to create NewsAPI request")
+		return
+	}
+
+	req.Header.Set("X-Api-Key", apiKey)
+
+	// Call NewsAPI
+	client := &http.Client{Timeout: 8 * time.Second}
+	res, err := client.Do(req)
+	if err != nil {
+		writeJSONError(w, http.StatusBadGateway, "failed to call NewsAPI")
+		return
+	}
+	defer res.Body.Close()
+
+	if res.StatusCode != http.StatusOK {
+		writeJSONError(w, http.StatusBadGateway, "NewsAPI returned non-200 response")
+		return
+	}
+
+	var newsResp NewsAPIResponse
+	if err := json.NewDecoder(res.Body).Decode(&newsResp); err != nil {
+		writeJSONError(w, http.StatusBadGateway, "failed to decode NewsAPI response")
+		return
+	}
+
+	// For each article:
+	// 1. Try scraping full article text
+	// 2. Fallback to NewsAPI snippet if scraping fails
+	// 3. Send text to Groq for summarization
+	for i := range newsResp.Articles {
+		fullText, err := extractArticleText(newsResp.Articles[i].URL)
+		if err != nil || strings.TrimSpace(fullText) == "" {
+			fullText = "Title: " + newsResp.Articles[i].Title + "\n" +
+				"Description: " + newsResp.Articles[i].Description + "\n" +
+				"Content: " + newsResp.Articles[i].Content
+		}
+
+		// Send the article text (scraped or fallback) to Groq for summarization
+		summary, err := summarizeWithGroq(fullText)
+
+		if err != nil {
+			// If summarization fails, store a fallback message
+			newsResp.Articles[i].Summary = "summary unavailable"
+			continue
+		}
+		// Save the generated summary into the article
+		newsResp.Articles[i].Summary = summary
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(newsResp)
+}

--- a/backend/cmd/api/scrape.go
+++ b/backend/cmd/api/scrape.go
@@ -1,0 +1,79 @@
+package main
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+
+	readability "github.com/mackee/go-readability"
+)
+
+// extractArticleText takes a news article URL,
+// fetches the webpage, extracts the main readable content,
+// and returns it as plain text.
+func extractArticleText(articleURL string) (string, error) {
+
+	// Create an HTTP client with timeout
+	// so requests don’t hang forever like a bad conversation
+	client := &http.Client{
+		Timeout: 12 * time.Second,
+	}
+
+	// Build a GET request for the article URL
+	req, err := http.NewRequest(http.MethodGet, articleURL, nil)
+	if err != nil {
+		return "", fmt.Errorf("failed to create article request: %w", err)
+	}
+
+	// Set User-Agent header to mimic a real browser
+	// some sites block “unknown” clients otherwise
+	req.Header.Set("User-Agent", "Mozilla/5.0 (compatible; NewsSummarizer/1.0)")
+
+	// Send the HTTP request to fetch the webpage
+	res, err := client.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("failed to fetch article page: %w", err)
+	}
+	defer res.Body.Close()
+
+	// Ensure we got a valid response (HTTP 200 OK)
+	if res.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("article page returned status %d", res.StatusCode)
+	}
+
+	// Read the entire HTML body of the webpage
+	body, err := io.ReadAll(res.Body)
+	if err != nil {
+		return "", fmt.Errorf("failed to read article page: %w", err)
+	}
+
+	// Initialize readability options (default settings)
+	options := readability.DefaultOptions()
+
+	// Extract the main article content from raw HTML
+	// this removes ads, navbars, sidebars, etc.
+	article, err := readability.Extract(string(body), options)
+	if err != nil {
+		return "", fmt.Errorf("failed to extract readable content: %w", err)
+	}
+
+	// Convert extracted content into plain text
+	// (clean, readable article body)
+	text := strings.TrimSpace(readability.ExtractTextContent(article.Root))
+
+	// Fallback: if text extraction fails,
+	// convert content into markdown instead
+	if text == "" && article.Root != nil {
+		text = strings.TrimSpace(readability.ToMarkdown(article.Root))
+	}
+
+	// If still empty, something went wrong
+	if text == "" {
+		return "", fmt.Errorf("extracted article text is empty")
+	}
+
+	// Return the cleaned article text
+	return text, nil
+}

--- a/backend/cmd/api/utils.go
+++ b/backend/cmd/api/utils.go
@@ -1,0 +1,66 @@
+package main
+
+import (
+	"bufio"
+	"encoding/json"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+func writeJSONError(w http.ResponseWriter, status int, message string) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+
+	_ = json.NewEncoder(w).Encode(map[string]any{
+		"success": false,
+		"error":   message,
+	})
+}
+
+func loadDotEnv() {
+	paths := []string{".env"}
+
+	for _, p := range paths {
+		if err := parseDotEnv(p); err == nil {
+			return
+		}
+	}
+}
+
+func parseDotEnv(path string) error {
+	f, err := os.Open(filepath.Clean(path))
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+
+	scanner := bufio.NewScanner(f)
+
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+
+		parts := strings.SplitN(line, "=", 2)
+		if len(parts) != 2 {
+			continue
+		}
+
+		key := strings.TrimSpace(parts[0])
+		val := strings.Trim(strings.TrimSpace(parts[1]), `"'`)
+
+		if key == "" {
+			continue
+		}
+
+		if _, exists := os.LookupEnv(key); !exists {
+			_ = os.Setenv(key, val)
+		}
+	}
+
+	return scanner.Err()
+}

--- a/backend/go.mod
+++ b/backend/go.mod
@@ -1,0 +1,10 @@
+module news_social/backend
+
+go 1.25.0
+
+require (
+	github.com/go-chi/chi/v5 v5.2.5
+	github.com/mackee/go-readability v0.3.1
+)
+
+require golang.org/x/net v0.39.0 // indirect

--- a/backend/go.sum
+++ b/backend/go.sum
@@ -1,0 +1,6 @@
+github.com/go-chi/chi/v5 v5.2.5 h1:Eg4myHZBjyvJmAFjFvWgrqDTXFyOzjj7YIm3L3mu6Ug=
+github.com/go-chi/chi/v5 v5.2.5/go.mod h1:X7Gx4mteadT3eDOMTsXzmI4/rwUpOwBHLpAfupzFJP0=
+github.com/mackee/go-readability v0.3.1 h1:DUwcwlhNLPtrBkGyJPcKp51oOKBvZvvMDPPFFLUIcKc=
+github.com/mackee/go-readability v0.3.1/go.mod h1:lfyLr0PJ+fQ+z6r6IBrexFxP4AoVsaDJAGvMcoJ4UAM=
+golang.org/x/net v0.39.0 h1:ZCu7HMWDxpXpaiKdhzIfaltL9Lp31x/3fCP11bc6/fY=
+golang.org/x/net v0.39.0/go.mod h1:X7NRbYVEA+ewNkCNyJ513WmMdQ3BineSwVtN2zD/d+E=


### PR DESCRIPTION
## Summary
This PR adds the scraper flow, integrates the LLM API layer, adds unit tests, and refactors the main API flow.

## Changes made
- added scraper implementation
- added LLM API integration
- added unit tests for backend logic
- refactored `main.go`
- updated Go module files for dependencies

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * News endpoint now returns AI-generated, article-level summaries and extracts full article text when available.

* **Tests**
  * Added a comprehensive test suite covering API handlers, env loading, HTTP integrations, and end-to-end news flow.

* **Chores**
  * Updated project dependencies and added .gitignore entries to exclude build artifacts, backups, and macOS junk.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->